### PR TITLE
Added a printf for each test passing/failing in test fest

### DIFF
--- a/Testing/harness.rkt
+++ b/Testing/harness.rkt
@@ -415,6 +415,7 @@
            (for/list ([t all-tests]
                       [r results])
              (match-define `(,in-fname ,input* ,out-fname ,expected-out) t)
+	     (printf "(results for test ~a ~a)\n" in-fname (if (= r 1) "pass" "fail"))
              (and (= r 1)
                   (list in-fname out-fname)))))
   (displayln

--- a/Testing/harness.rkt
+++ b/Testing/harness.rkt
@@ -415,7 +415,7 @@
            (for/list ([t all-tests]
                       [r results])
              (match-define `(,in-fname ,input* ,out-fname ,expected-out) t)
-	     (printf "(results for test ~a ~a)\n" in-fname (if (= r 1) "pass" "fail"))
+             (printf "(results for test ~a ~a)\n" in-fname (if (= r 1) "pass" "fail"))
              (and (= r 1)
                   (list in-fname out-fname)))))
   (displayln


### PR DESCRIPTION
Example output when running a group's tests against another student:

```
(results for test /course/cs4400f25/ta4400/all-repos/students/2/gentle-pandas/Tests/0-in.ss fail)
(results for test /course/cs4400f25/ta4400/all-repos/students/2/gentle-pandas/Tests/1-in.ss pass)
(results for test /course/cs4400f25/ta4400/all-repos/students/2/gentle-pandas/Tests/2-in.ss pass)
(results for test /course/cs4400f25/ta4400/all-repos/students/2/gentle-pandas/Tests/3-in.ss pass)
(results for test /course/cs4400f25/ta4400/all-repos/students/2/gentle-pandas/Tests/4-in.ss pass)
```

This allows the auto grader to check the number of occurences of "Tests/0-in.ss fail" in the bonus.txt file. This way, if "0-in.ss fail" breaks 3 groups' programs, we can reward points. 